### PR TITLE
Fix invalid link, header link, added contribution guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,110 @@
+# Contributing 
+This is a document outlining how to contribute to the Tūhura Tech wiki.
+
+There are two main ways of contributing:  
+- Suggesting - this involves creating a new [issue on Github](https://github.com/Tuhura-Tech/Wiki/issues) and informing us of a way to improve the wiki. Alturnatively, you can notify the team directly on our [Discord server](https://github.com/Tuhura-Tech/Wiki/issues)
+- Directly - to do this you need to [fork our repository](https://github.com/Tuhura-Tech/Wiki/fork) and editing it, then creating a pull request to merge with the main site
+
+## Issues and suggestions
+If you have a suggestion or an issue you have found with the wiki please go to our [Github issues](https://github.com/Tuhura-Tech/Wiki/issues) page and start a new issue
+
+### Creating an issue
+For a new issue on the [Github issues](https://github.com/Tuhura-Tech/Wiki/issues) issues page, press 'New issue'   
+From there decide which issue you would like to raise:
+- Docs Request - this is for if you have information that you would like to be documented on the Tūhura Tech wiki, or you have a request for something you would like us to look into and document
+- Report a security vulnerability - if you have seen a security vulnerability, let us know privately here
+
+### Documentation request
+
+#### Title
+Try and keep the title for what you want to be request short and simple.  
+A good title is no more than a few words, for example "Python Introduction" or "Database backend" are good titles.
+
+#### Short description
+This is to expand your request into a full sentence or two. Try and keep this simple without going into detail.  
+A good example of a short description is "Please write a guide on how to use markdown"
+
+#### Detailed/additional information 
+This is optional.  
+If you have information you would like to be cut down and added to the wiki add it here. 
+
+Or, if you have screenshots to help explain what you would like to be added paste them here.  
+The easiest way to add an image is to `right click > copy image` on most platforms like Google Chrome or Discord, and then using `ctrl + v` in the issue to paste it as a markdown link
+
+## Directly writing documentation
+It's awesome you want to help us document and create resources for people to learn from! To get started you will need to set a few things up
+
+### Setting up
+To contribute you first need to hold a copy of our wiki on your device to edit it. First off, create a [fork of the repository](https://github.com/Tuhura-Tech/Wiki/fork)
+
+The simplest way to clone [the repository](https://github.com/Tuhura-Tech/Wiki) is to use [Github Desktop](https://desktop.github.com).   
+
+Github Desktop is available for [Windows](https://central.github.com/deployments/desktop/desktop/latest/win32) and [macOS](https://central.github.com/deployments/desktop/desktop/latest/darwin)  
+
+Open the installer and let it run. Then "Clone a repository from the Internet", which can also be reached from `File > Clone repository...` or `ctrl + shift + o`. Go to the third tab and paste in the link to your cloned branch and choose an empty local path, then press 'Clone'.
+
+From here you can open it in your file explorer or preferred code editor via the buttons or manually in those programs
+
+### Writing in markdown 
+[markdownguide.org](https://www.markdownguide.org) has a wonderful [cheat sheet](https://www.markdownguide.org/cheat-sheet/) for writing in markdown. All of the documentation is written in markdown so knowing this is crucial. If you would like to see examples of how to format your documentation go to the documentation we have already written and look at the raw markdown. The most commonly used syntax are # to indicate titles and subtitles so be sure to get familiar with that.
+
+### Testing your version of the site
+The site is written in [vitepress](https://vitepress.dev), which is a simlpe way to write documentation. They have a simple [getting started guide](https://vitepress.dev/guide/getting-started) which will help you install and use vitepress.
+
+To summarize what you most likely need to know:
+- Open the console for your operating system and run the command `npm install -D vitepress`. The [getting started guide](https://vitepress.dev/guide/getting-started) has alturnatives to npm if your system does not recognize it as a command
+- Use the `cd` command to navigate to the install location of our wiki's root folder
+- Use the command `npm run docs:dev` to start the site at http://localhost:5174/  
+If you run into an error, read it and try to understand what's wrong. If you cannot find a solution consult the [vitepress documentation](https://vitepress.dev/guide/getting-started)
+
+### Adding to documentation
+In the `/docs/` folder you will find many files.  
+You can ignore any `index.md` files, and any `.vitepress` files.
+
+From here navigate to the documentation you would like to add to and add what you would like to. Try and keep in line with the style already used in other documentation.
+
+Once you have made your changes [test how the markdown will look](https://markdownlivepreview.com) and look at the changes on a local host of the site. 
+
+Finally, back on Github Desktop make sure the file(s) you have changed are ticked in the changes tab on your Wiki branch repository, give them a summary, and then commit them. 
+
+### Adding new documentation
+
+#### New page in a present topic
+Adding a new page is more complex than adding to a page that is already there. First, navigate to the file where you would like to make a new page that corrosponds to the location on the site. For example if you wanted to write about an NCEA standard go to `docs/ncea/` and then the level it is for. There, create a new markdown file named `your documentation name.md`.
+
+Then, in `/docs/.vitepress/config/sidebar.ts` add your page.
+This is an example of adding `example.md` to the cybersecurity topic
+```
+"/guides/cybersecurity": [
+    {
+      text: "Cyber Security",
+      link: "/guides/cybersecurity/",
+      items: [{ text: "Example", link: "/guides/cybersecurity/example"}],
+    },
+  ],
+```
+The only changed part of the code was `items: [],` to `items: [{ text: "Example", link: "/guides/cybersecurity/example"}],`
+
+#### New page in a new topic
+If you need to create a new topic folder for your documentation, make the new folder in `/docs/guides` and add the markdown file there
+
+Then, in `/docs/.vitepress/config/sidebar.ts` add your topic and page.  
+This is an example of a topic called `example` with a file called `example.md`
+```
+  "/guides/example": [
+    {
+      text: "Example",
+      link: "/guides/example/",
+      items: [{ text: "Example", link: "/guides/example/example.md" }],
+    },
+  ],
+```
+You must also change `/docs/.vitepress/config/nav.ts`   
+This is that same example for nav.ts
+```
+{
+  text: "Example",
+  link: "/guides/example/",
+  activeMatch: "/guides/example/"
+},
+```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,7 +86,7 @@ This is an example of adding `example.md` to the cybersecurity topic
 The only changed part of the code was `items: [],` to `items: [{ text: "Example", link: "/guides/cybersecurity/example"}],`
 
 #### New page in a new topic
-If you need to create a new topic folder for your documentation, make the new folder in `/docs/guides` and add the markdown file there
+If you need to create a new topic folder for your documentation, make the new folder in `/docs/guides` and add the markdown file there. Also add an `index.md` file there, this file is the home page for your topic so describe the topic here briefly. 
 
 Then, in `/docs/.vitepress/config/sidebar.ts` add your topic and page.  
 This is an example of a topic called `example` with a file called `example.md`
@@ -108,3 +108,7 @@ This is that same example for nav.ts
   activeMatch: "/guides/example/"
 },
 ```
+Finally, back on Github Desktop make sure the file(s) you have changed are ticked in the changes tab on your Wiki branch repository, give them a summary, and then commit them. 
+
+### Merging your changed
+Finally, to add your documentation to the main site. To do this create a [new pull request](https://github.com/Tuhura-Tech/Wiki/compare)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,34 +2,38 @@
 This is a document outlining how to contribute to the Tūhura Tech wiki.
 
 There are two main ways of contributing:  
-- Suggesting - this involves creating a new [issue on Github](https://github.com/Tuhura-Tech/Wiki/issues) and informing us of a way to improve the wiki. Alturnatively, you can notify the team directly on our [Discord server](https://github.com/Tuhura-Tech/Wiki/issues)
+- Suggesting - this involves creating a new [issue on Github](https://github.com/Tuhura-Tech/Wiki/issues) and informing us of a way to improve the wiki. Alternatively, you can notify the team directly on our [Discord server](https://discord.gg/PNxh7cwKfQ)
 - Directly - to do this you need to [fork our repository](https://github.com/Tuhura-Tech/Wiki/fork) and editing it, then creating a pull request to merge with the main site
 
 ## Issues and suggestions
 If you have a suggestion or an issue you have found with the wiki please go to our [Github issues](https://github.com/Tuhura-Tech/Wiki/issues) page and start a new issue
 
+Or you could notify the team directly on our [Discord server](https://discord.gg/PNxh7cwKfQ) or start a thread on the [Github discussions](https://github.com/Tuhura-Tech/Wiki/discussions) page
+
 ### Creating an issue
-For a new issue on the [Github issues](https://github.com/Tuhura-Tech/Wiki/issues) issues page, press 'New issue'   
+Choose which issue you you would like to raise [here](https://github.com/Tuhura-Tech/Wiki/issues/new/choose)
 From there decide which issue you would like to raise:
 - Docs Request - this is for if you have information that you would like to be documented on the Tūhura Tech wiki, or you have a request for something you would like us to look into and document
 - Report a security vulnerability - if you have seen a security vulnerability, let us know privately here
 
-### Documentation request
+You can also directly suggest to us via our [Discord server](https://github.com/Tuhura-Tech/Wiki/issues)
+
+### Documentation request guide
 
 #### Title
-Try and keep the title for what you want to be request short and simple.  
+Try to keep the title for what you want to be requested short and simple.  
 A good title is no more than a few words, for example "Python Introduction" or "Database backend" are good titles.
 
 #### Short description
-This is to expand your request into a full sentence or two. Try and keep this simple without going into detail.  
+This is to expand your request into a full sentence or two. Try to keep this simple without going into detail.  
 A good example of a short description is "Please write a guide on how to use markdown"
 
 #### Detailed/additional information 
 This is optional.  
 If you have information you would like to be cut down and added to the wiki add it here. 
 
-Or, if you have screenshots to help explain what you would like to be added paste them here.  
-The easiest way to add an image is to `right click > copy image` on most platforms like Google Chrome or Discord, and then using `ctrl + v` in the issue to paste it as a markdown link
+Or, if you have screenshots to help explain what you would like to be added, paste them here.  
+The easiest way to add an image is something similar to `right click > copy image` on most platforms like Google Chrome or Discord, and then using `right click > paste` in the issue to paste it as a markdown link
 
 ## Directly writing documentation
 It's awesome you want to help us document and create resources for people to learn from! To get started you will need to set a few things up
@@ -37,40 +41,41 @@ It's awesome you want to help us document and create resources for people to lea
 ### Setting up
 To contribute you first need to hold a copy of our wiki on your device to edit it. First off, create a [fork of the repository](https://github.com/Tuhura-Tech/Wiki/fork)
 
-The simplest way to clone [the repository](https://github.com/Tuhura-Tech/Wiki) is to use [Github Desktop](https://desktop.github.com).   
+The simplest way to clone [the repository](https://github.com/Tuhura-Tech/Wiki) is to use [Visual Studio Code](https://code.visualstudio.com), you can also use VSCode to edit markdown and typescript.  
+Learn how to clone a git repository using VSCode [here](https://learn.microsoft.com/en-us/azure/developer/javascript/how-to/with-visual-studio-code/clone-github-repository)
 
+Alternatively, Github Desktop is another good way to manage git files.  
 Github Desktop is available for [Windows](https://central.github.com/deployments/desktop/desktop/latest/win32) and [macOS](https://central.github.com/deployments/desktop/desktop/latest/darwin)  
-
 Open the installer and let it run. Then "Clone a repository from the Internet", which can also be reached from `File > Clone repository...` or `ctrl + shift + o`. Go to the third tab and paste in the link to your cloned branch and choose an empty local path, then press 'Clone'.
-
 From here you can open it in your file explorer or preferred code editor via the buttons or manually in those programs
 
 ### Writing in markdown 
-[markdownguide.org](https://www.markdownguide.org) has a wonderful [cheat sheet](https://www.markdownguide.org/cheat-sheet/) for writing in markdown. All of the documentation is written in markdown so knowing this is crucial. If you would like to see examples of how to format your documentation go to the documentation we have already written and look at the raw markdown. The most commonly used syntax are # to indicate titles and subtitles so be sure to get familiar with that.
+[markdownguide.org](https://www.markdownguide.org) has a wonderful [cheat sheet](https://www.markdownguide.org/cheat-sheet/) for writing in markdown. All of the documentation is written in markdown so knowing this is crucial. If you would like to see examples of how to format your documentation go to the documentation we have already written and look at the raw markdown. The most commonly used syntax are # to indicate titles and subtitles so be sure to get familiar with that.  
+
+If your documentation requires diagrams please use the plugin we have chosen, [mermaid](https://emersonbottero.github.io/vitepress-plugin-mermaid/).
 
 ### Testing your version of the site
-The site is written in [vitepress](https://vitepress.dev), which is a simlpe way to write documentation. They have a simple [getting started guide](https://vitepress.dev/guide/getting-started) which will help you install and use vitepress.
+The site is written in [vitepress](https://vitepress.dev), which is a simple way to write documentation. They have a simple [getting started guide](https://vitepress.dev/guide/getting-started) which will help you install and use vitepress if you want to make your own site.
 
-To summarize what you most likely need to know:
-- Open the console for your operating system and run the command `npm install -D vitepress`. The [getting started guide](https://vitepress.dev/guide/getting-started) has alturnatives to npm if your system does not recognize it as a command
-- Use the `cd` command to navigate to the install location of our wiki's root folder
-- Use the command `npm run docs:dev` to start the site at http://localhost:5174/  
-If you run into an error, read it and try to understand what's wrong. If you cannot find a solution consult the [vitepress documentation](https://vitepress.dev/guide/getting-started)
+Our site already has vitepress and its dependencies installed so all you need to do is:
+- Open the console for your operating system and use the `cd` command to navigate to the install location of our wiki's root folder
+- Use the command `yarn run docs:dev` to start the site at http://localhost:5174/  
+If you run into an error, read it and try to understand what's wrong. If you cannot find a solution ask for help in the [repo discussions](https://github.com/Tuhura-Tech/Wiki/discussions) or our [discord server](https://discord.gg/PNxh7cwKfQ)
 
-### Adding to documentation
+### Adding to a page already present
 In the `/docs/` folder you will find many files.  
 You can ignore any `index.md` files, and any `.vitepress` files.
 
 From here navigate to the documentation you would like to add to and add what you would like to. Try and keep in line with the style already used in other documentation.
 
-Once you have made your changes [test how the markdown will look](https://markdownlivepreview.com) and look at the changes on a local host of the site. 
+Once you have made your changes look at the changes on a local host of the site to see if you are satisfied with them.
 
 Finally, back on Github Desktop make sure the file(s) you have changed are ticked in the changes tab on your Wiki branch repository, give them a summary, and then commit them. 
 
-### Adding new documentation
+### Adding a new documentation page
 
 #### New page in a present topic
-Adding a new page is more complex than adding to a page that is already there. First, navigate to the file where you would like to make a new page that corrosponds to the location on the site. For example if you wanted to write about an NCEA standard go to `docs/ncea/` and then the level it is for. There, create a new markdown file named `your documentation name.md`.
+Adding a new page is more complex than adding to a page that is already there. First, navigate to the file where you would like to make a new page that corresponds to the location on the site. For example if you wanted to write about an NCEA standard go to `docs/ncea/` and then the level it is for. There, create a new markdown file named `your documentation name.md`.
 
 Then, in `/docs/.vitepress/config/sidebar.ts` add your page.
 This is an example of adding `example.md` to the cybersecurity topic
@@ -86,7 +91,7 @@ This is an example of adding `example.md` to the cybersecurity topic
 The only changed part of the code was `items: [],` to `items: [{ text: "Example", link: "/guides/cybersecurity/example"}],`
 
 #### New page in a new topic
-If you need to create a new topic folder for your documentation, make the new folder in `/docs/guides` and add the markdown file there. Also add an `index.md` file there, this file is the home page for your topic so describe the topic here briefly. 
+If you need to create a new topic folder for your documentation, make the new folder in `/docs/guides` and add the markdown file inside that folder. Make sure the folder and file is lowercase and has no spaces/numbers/special characters. Also add an `index.md` file there, this file is the home page for your topic so describe the topic here briefly. 
 
 Then, in `/docs/.vitepress/config/sidebar.ts` add your topic and page.  
 This is an example of a topic called `example` with a file called `example.md`

--- a/docs/.vitepress/config/sidebar.ts
+++ b/docs/.vitepress/config/sidebar.ts
@@ -11,7 +11,7 @@ export default {
             items: [
                 {
                     text: "Web Internal using Flask",
-                    link: "/ncea/level-2/web-flask",
+                    link: "/ncea/level-2/web",
                 },
             ],
         },

--- a/docs/.vitepress/config/sidebar.ts
+++ b/docs/.vitepress/config/sidebar.ts
@@ -1,77 +1,80 @@
 export default {
-  "/ncea/level-1": [
-    {
-      text: "NCEA Level 1",
-      link: "/ncea/level-1",
-      items: [],
-    },
-  ],
-  "/ncea/level-2": [
-    {
-      text: "NCEA Level 2",
-      link: "/ncea/level-2",
-      items: [
+    "/ncea/level-1": [
         {
-          text: "Web Internal",
-          link: "/ncea/level-2/web-flask",
+            text: "NCEA Level 1",
+            items: [],
         },
-      ],
-    },
-  ],
-  "/ncea/level-3": [
-    {
-      text: "NCEA Level 3",
-      link: "/ncea/level-3",
-      items: [],
-    },
-  ],
-  "/guides/3d-printing": [
-    {
-      text: "3D Printing",
-      link: "/guides/3d-printing",
-      items: [],
-    },
-  ],
-  "/guides/cybersecurity": [
-    {
-      text: "Cyber Security",
-      link: "/guides/cybersecurity",
-      items: [],
-    },
-  ],
-  "/guides/electronics": [
-    {
-      text: "Electronics",
-      link: "/guides/electronics",
-      items: [],
-    },
-  ],
-  "/guides/python": [
-    {
-      text: "Python",
-      link: "/guides/python",
-      items: [{ text: "Setting up", link: "/guides/python/setting-up" }],
-    },
-  ],
-  "/guides/rust": [
-    {
-      text: "Rust",
-      link: "/guides/rust",
-      items: [],
-    },
-  ],
-  "/guides/java": [
-    {
-      text: "Java",
-      link: "/guides/java",
-      items: [],
-    },
-  ],
-  "/guides/git": [
-    {
-      text: "Git",
-      link: "/guides/git",
-      items: [],
-    },
-  ],
+    ],
+    "/ncea/level-2": [
+        {
+            text: "NCEA Level 2",
+            items: [
+                {
+                    text: "Web Internal using Flask",
+                    link: "/ncea/level-2/web-flask",
+                },
+            ],
+        },
+    ],
+    "/ncea/level-3": [
+        {
+            text: "NCEA Level 3",
+            items: [],
+        },
+    ],
+    "/guides/3d-printing": [
+        {
+            text: "3D Printing",
+            items: [],
+        },
+    ],
+    "/guides/cybersecurity": [
+        {
+            text: "Cyber Security",
+            items: [],
+        },
+    ],
+    "/guides/electronics": [
+        {
+            text: "Electronics",
+            items: [],
+        },
+    ],
+    "/guides/python": [
+        {
+            text: "Python",
+            items: [{ text: "Setting up", link: "/guides/python/setting-up" }],
+        },
+    ],
+    "/guides/rust": [
+        {
+            text: "Rust",
+            items: [],
+        },
+    ],
+    "/guides/java": [
+        {
+            text: "Java",
+            items: [],
+        },
+    ],
+    "/guides/git": [
+        {
+            text: "Git",
+            items: [
+                {
+                    text: "Setting Up",
+                    link: "/guides/git/setting-up",
+                },
+                {
+                    text: "Git Basics",
+                    link: "/guides/git/basics",
+                },
+                {
+                    text: "Tips and Tricks",
+                    link: "/guides/git/tips-and-tricks",
+                },
+            ],
+        },
+    ],
 };

--- a/docs/.vitepress/config/sidebar.ts
+++ b/docs/.vitepress/config/sidebar.ts
@@ -11,7 +11,7 @@ export default {
       items: [
         {
           text: "Web Internal using Flask",
-          link: "/ncea/level-2/web",
+          link: "/ncea/level-2/web-flask",
         },
       ],
     },

--- a/docs/.vitepress/config/sidebar.ts
+++ b/docs/.vitepress/config/sidebar.ts
@@ -1,80 +1,80 @@
 export default {
-    "/ncea/level-1": [
+  "/ncea/level-1": [
+    {
+      text: "NCEA Level 1",
+      items: [],
+    },
+  ],
+  "/ncea/level-2": [
+    {
+      text: "NCEA Level 2",
+      items: [
         {
-            text: "NCEA Level 1",
-            items: [],
+          text: "Web Internal using Flask",
+          link: "/ncea/level-2/web",
         },
-    ],
-    "/ncea/level-2": [
+      ],
+    },
+  ],
+  "/ncea/level-3": [
+    {
+      text: "NCEA Level 3",
+      items: [],
+    },
+  ],
+  "/guides/3d-printing": [
+    {
+      text: "3D Printing",
+      items: [],
+    },
+  ],
+  "/guides/cybersecurity": [
+    {
+      text: "Cyber Security",
+      items: [],
+    },
+  ],
+  "/guides/electronics": [
+    {
+      text: "Electronics",
+      items: [],
+    },
+  ],
+  "/guides/python": [
+    {
+      text: "Python",
+      items: [{ text: "Setting up", link: "/guides/python/setting-up" }],
+    },
+  ],
+  "/guides/rust": [
+    {
+      text: "Rust",
+      items: [],
+    },
+  ],
+  "/guides/java": [
+    {
+      text: "Java",
+      items: [],
+    },
+  ],
+  "/guides/git": [
+    {
+      text: "Git",
+      items: [
         {
-            text: "NCEA Level 2",
-            items: [
-                {
-                    text: "Web Internal using Flask",
-                    link: "/ncea/level-2/web",
-                },
-            ],
+          text: "Setting Up",
+          link: "/guides/git/setting-up",
         },
-    ],
-    "/ncea/level-3": [
         {
-            text: "NCEA Level 3",
-            items: [],
+          text: "Git Basics",
+          link: "/guides/git/basics",
         },
-    ],
-    "/guides/3d-printing": [
         {
-            text: "3D Printing",
-            items: [],
+          text: "Tips and Tricks",
+          link: "/guides/git/tips-and-tricks",
         },
-    ],
-    "/guides/cybersecurity": [
-        {
-            text: "Cyber Security",
-            items: [],
-        },
-    ],
-    "/guides/electronics": [
-        {
-            text: "Electronics",
-            items: [],
-        },
-    ],
-    "/guides/python": [
-        {
-            text: "Python",
-            items: [{ text: "Setting up", link: "/guides/python/setting-up" }],
-        },
-    ],
-    "/guides/rust": [
-        {
-            text: "Rust",
-            items: [],
-        },
-    ],
-    "/guides/java": [
-        {
-            text: "Java",
-            items: [],
-        },
-    ],
-    "/guides/git": [
-        {
-            text: "Git",
-            items: [
-                {
-                    text: "Setting Up",
-                    link: "/guides/git/setting-up",
-                },
-                {
-                    text: "Git Basics",
-                    link: "/guides/git/basics",
-                },
-                {
-                    text: "Tips and Tricks",
-                    link: "/guides/git/tips-and-tricks",
-                },
-            ],
-        },
-    ],
+      ],
+    },
+  ],
 };

--- a/docs/.vitepress/config/sidebar.ts
+++ b/docs/.vitepress/config/sidebar.ts
@@ -2,12 +2,14 @@ export default {
   "/ncea/level-1": [
     {
       text: "NCEA Level 1",
+      link: "/ncea/level-1",
       items: [],
     },
   ],
   "/ncea/level-2": [
     {
       text: "NCEA Level 2",
+      link: "/ncea/level-2",
       items: [
         {
           text: "Web Internal",
@@ -19,48 +21,56 @@ export default {
   "/ncea/level-3": [
     {
       text: "NCEA Level 3",
+      link: "/ncea/level-3",
       items: [],
     },
   ],
   "/guides/3d-printing": [
     {
       text: "3D Printing",
+      link: "/guides/3d-printing",
       items: [],
     },
   ],
   "/guides/cybersecurity": [
     {
       text: "Cyber Security",
+      link: "/guides/cybersecurity",
       items: [],
     },
   ],
   "/guides/electronics": [
     {
       text: "Electronics",
+      link: "/guides/electronics",
       items: [],
     },
   ],
   "/guides/python": [
     {
       text: "Python",
+      link: "/guides/python",
       items: [{ text: "Setting up", link: "/guides/python/setting-up" }],
     },
   ],
   "/guides/rust": [
     {
       text: "Rust",
+      link: "/guides/rust",
       items: [],
     },
   ],
   "/guides/java": [
     {
       text: "Java",
+      link: "/guides/java",
       items: [],
     },
   ],
   "/guides/git": [
     {
       text: "Git",
+      link: "/guides/git",
       items: [],
     },
   ],

--- a/docs/.vitepress/config/sidebar.ts
+++ b/docs/.vitepress/config/sidebar.ts
@@ -11,7 +11,7 @@ export default {
       items: [
         {
           text: "Web Internal",
-          link: "/ncea/level-2/web",
+          link: "/ncea/level-2/web-flask",
         },
       ],
     },

--- a/docs/ncea/level-2/web-flask.md
+++ b/docs/ncea/level-2/web-flask.md
@@ -478,74 +478,6 @@ def index():
 
 Finally, we need to use the `get_db` function to get the database connection in our route. This will allow us to access the database from our route. An example of this is shown above. We can then use our database connection to get the users from the database and return them in our route.
 
-
-### API or Jinja Templates
-
-## Documenting your API
-One of the most important parts of any API is the documentation. This is because it allows other people to use your API without having to read your code. There are a few different ways to document your API but we recommend using the [OpenAPI Specification](https://spec.openapis.org/oas/v3.1.0). This is a standard that is used by many different tools and is a good way to document your API. One of the big advantages is that the documentation can automatically be generated from your code and build an easy to read documentation page such as [this](https://petstore.swagger.io/).
-
-To create a documentation page for your API you will need to install the [Flasgger](https://github.com/flasgger/flasgger) library. This library allows you to add OpenAPI documentation to your Flask application. To install it you can run the following command:
-
-```sh
-$ poetry add flasgger
-```
-
-Once you have installed the library, flasgger can use your docstrings to automatically generate documentation. An example of this is below (this is taken from the flasgger documentation):
-
-```python
-from flask import Flask, jsonify
-from flasgger import Swagger
-
-app = Flask(__name__)
-swagger = Swagger(app)
-
-@app.route('/colors/<palette>/')
-def colors(palette):
-    """Example endpoint returning a list of colors by palette
-    This is using docstrings for specifications.
-    ---
-    parameters:
-      - name: palette
-        in: path
-        type: string
-        enum: ['all', 'rgb', 'cmyk']
-        required: true
-        default: all
-    definitions:
-      Palette:
-        type: object
-        properties:
-          palette_name:
-            type: array
-            items:
-              $ref: '#/definitions/Color'
-      Color:
-        type: string
-    responses:
-      200:
-        description: A list of colors (may be filtered by palette)
-        schema:
-          $ref: '#/definitions/Palette'
-        examples:
-          rgb: ['red', 'green', 'blue']
-    """
-    all_colors = {
-        'cmyk': ['cyan', 'magenta', 'yellow', 'black'],
-        'rgb': ['red', 'green', 'blue']
-    }
-    if palette == 'all':
-        result = all_colors
-    else:
-        result = {palette: all_colors.get(palette)}
-
-    return jsonify(result)
-
-if __name__ == "__main__":
-  app.run(debug=True)
-```
-
-You can then visit [` http://127.0.0.1:5000/apidocs/`](http://127.0.0.1:5000/apidocs/) to see the documentation page.
-
 ## Further Resources
 A copy of all the code used as a working Flask application can be found [here](https://github.com/Tuhura-Tech/ncea-lvl2-web-flask-example). Below is a set of useful resources and links to help you learn more about Flask and how to use it.
 
@@ -554,4 +486,3 @@ A copy of all the code used as a working Flask application can be found [here](h
 - [sqlite3 Documentation](https://docs.python.org/3/library/sqlite3.html)
 - [Jinja Documentation](https://jinja.palletsprojects.com/en/3.0.x/templates/)
 - [OpenAPI Specification](https://spec.openapis.org/oas/v3.1.0)
-- [Flasgger Documentation](https://github.com/flasgger/flasgger)


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/102631339/229333361-38895c5d-cbe9-4ed6-ab06-954bf1bf0f8f.png)
Used to say /ncea/level-2/web changed it to web-flask since that's the actual link, it used to lead to a 404

![image](https://user-images.githubusercontent.com/102631339/229333391-18f2085e-af8d-4b86-a014-e9a9bbd77178.png)
![image](https://user-images.githubusercontent.com/102631339/229333404-b97b9791-59f7-4188-bbb2-8982b3ab61c6.png)

The sidebar on the site's headers didn't lead back to the main page. For example on python if you went to getting started you couldn't go back to the main page that said WIP, which isn't bad right now but it'll be important later. I _think_ this is the right way to fix that but I'm just shooting in the dark ngl
Revert this change if it doesn't work