### PR TITLE
fix: Change order of creative coding

### DIFF
--- a/src/content/docs/guides/javascript/creative-coding/paintbrush.mdx
+++ b/src/content/docs/guides/javascript/creative-coding/paintbrush.mdx
@@ -1,6 +1,8 @@
 ---
 title: Paintbrush - Beginner
 description: This is how to create a simple paintbrush effect in p5.js.
+sidebar:
+    order: 2
 ---
 
 import { Tabs, TabItem } from "@astrojs/starlight/components";

--- a/src/content/docs/guides/javascript/creative-coding/start-here.mdx
+++ b/src/content/docs/guides/javascript/creative-coding/start-here.mdx
@@ -1,6 +1,8 @@
 ---
 title: Start Here
 description: This is how to start p5.js project.
+sidebar:
+    order: 1
 ---
 
 ## Intro


### PR DESCRIPTION
It was just backwards, probably should have the 'start here' at the top