### PR TITLE
refactor: Touching up the 3D docs

### DIFF
--- a/src/content/docs/guides/game-design/godot/3d.mdx
+++ b/src/content/docs/guides/game-design/godot/3d.mdx
@@ -5,7 +5,7 @@ sidebar:
     order: 2
 ---
 
-This is a guide for making a 3-dimentional game in [Godot](https://godotengine.org/). If you are unfamiliar with Godot check out the [Godot basics](/guides/game-design/godot/basics) doc.
+This is a guide for making a 3-dimentional game in [Godot](https://godotengine.org/). If you are unfamiliar with Godot, check out the [Godot basics](/guides/game-design/godot/basics) doc.
 
 :::note[Version]
 This guide is up-to-date with Godot 4.1.3 stable official release but will most likely work with any 4.x release.
@@ -35,23 +35,24 @@ Press down the middle mouse button to rotate the camera. Zoom in and out by scro
 If you do not have a middle mouse button to press, go to Editor > Editor Settings... > Editors > 3D and turn Emulate 3 Button Mouse on. Now you will use Alt to rotate and Shift to pan.
 :::
 
+
 ## Making the player
 
 ### Basic player and platform
 
 First, you're going to want to set up a platform for the player to stand on.
 
-1. Add a StaticBody3D as a child of Node3D.
-2. Add MeshInstance3D and CollisionShape3D as a child of StaticBody2D.
-3. In the inspector on the right, set MeshInstance3D's 'Mesh' property to New PlaneMesh. Set the CollisionShape3D's 'Shape' property to New BoxShape3D.
-4. Select CollisionShape3D and use the orange dots to shape the BoxShape3D to the same shape and size as the plane.
-5. As a child of Node3D, add CharacterBody3D.
-6. Add as a child of CharacterBody3D add Camera3D and CollisionShape3D.
+1. Add a **StaticBody3D** as a child of **Node3D**.
+2. Add **MeshInstance3D** and **CollisionShape3D** as a child of **StaticBody2D**.
+3. In the inspector on the right, set **MeshInstance3D**'s 'Mesh' property to **New PlaneMesh**. Set the **CollisionShape3D**'s 'Shape' property to **New BoxShape3D**.
+4. Select **CollisionShape3D** in the scene tree and use the orange dots to shape the **BoxShape3D** to the same shape and size as the plane.
+5. As a child of **Node3D**, add **CharacterBody3D**.
+6. Add as a child of **CharacterBody3D** add **Camera3D** and **CollisionShape3D**.
 7. Set the collision shape to capsule.
-8. Select the CharacterBody3D and move it up in the viewport until it's on top of the plane.
+8. Select the **CharacterBody3D** and move it up in the viewport until it's on top of the plane.
 9. Move the camera up so it's where the 'head' should be on the character.
-10. Give the CharacterBody3D a script and leave it as the default template script.
-11. One final step, add a DirectionalLight3D as a child of Node3D and rotate it to point down, this can be anywhere in the scene.
+10. Give the **CharacterBody3D** a script and leave it as the default template script.
+11. One final step, add a **DirectionalLight3D** as a child of **Node3D** and rotate it to point down, this can be anywhere in the scene.
 
 Phew! That was some setup, your scene should look something like this:
 ![Scene with player](../../../../../assets/godot/3D/InitialScene.png)
@@ -60,7 +61,11 @@ Now when you play the game and press **down** on the arrow keys you should move 
 ### First person camera
 
 Most modern 3D games have a first person camera, which can be pretty complicated. Open the script on your player.
-In this script, add these lines below `var gravity` and above `func _physics_process(delta):`:
+In this script, add these lines below `var gravity` and above `func _physics_process(delta):`:  
+
+:::warning[Copy pasting]
+More likely than not you'll copy paste this with spaces instead of tabs. Godot is strict with using just tabs. After copy pasting this, replace all the space indents with tabs.
+:::
 
 ```gdscript
 # Get the player camera
@@ -115,7 +120,7 @@ The mouse sensitivity variable controls how fast the camera moves, change it to 
 
 This is all you need for a basic character controller, but, as is good practice, you should change the input keys.
 
-Go to Project > Project Settings... > Input Map and in `Add New Action` add 'forward', 'left', 'backward', 'right', and 'jump'.
+Go to **Project > Project Settings... > Input Map** and in `Add New Action` add 'forward', 'left', 'backward', 'right', and 'jump'.
 
 Press the plus button next to each one and press the key you would like them to be.  
 It is recommended 'forward' should be W, 'left' should be A, 'backward' should be S, 'right' should be D, and 'jump' should be spacebar.
@@ -129,25 +134,25 @@ In your script, replace 'ui_up' with 'forward', 'ui_left' with 'left', 'ui_down'
 ### More platforms
 
 Now that you have a player, you need more platforms to jump on.
-Copy the StaticBody3D node and paste it as a child of Node3D.
+Copy the **StaticBody3D** node and paste it as a child of **Node3D**.
 
-Press R to change to scale mode and enlarge the StaticBody3D with the green square, use Shift to scale equally on all sides.  
+Press R to change to scale mode and enlarge the **StaticBody3D** with the green square, use Shift to scale equally on all sides.  
 While we're at it, use E to rotate the platform slightly and W to move it to the side so you have to jump to get to the platform.
 
 You can go back to the select tool with Q.
 
 Play the game and now you have another platform!
 
-Although, if you're paying attention, you might notice the warning sign on the StaticBody3D.
-To fix this, reset the size of your StaticBody3D by either pressing CTRL+Z or selecting the reset button in the inspector on the scale, which is found under Node3D > Transform.
+Although, if you're paying attention, you might notice the warning sign on the **StaticBody3D**.
+To fix this, reset the size of your **StaticBody3D** by either pressing CTRL+Z or selecting the reset button in the inspector on the scale, which is found under **Node3D > Transform**.
 
-Then select the MeshInstance3D and use scale mode to increase its size, and then select the CollisionShape3D with select mode and use the orange dots to increase its size to match the MeshInstance3D.
+Then select the **MeshInstance3D** and use scale mode to increase its size, and then select the **CollisionShape3D** with select mode and use the orange dots to increase its size to match the **MeshInstance3D**.
 
 You might notice the collision shape is changing both collision shapes, for this new platform and the original one.
-To fix that you'll need to select the CollisionShape3D and make a new BoxShape3D in the inspector since it's still using the same BoxShape3D as the previous platform.
+To fix that you'll need to select the **CollisionShape3D** and make a new **BoxShape3D** in the inspector since it's still using the same **BoxShape3D** as the previous platform.
 
 A better way of making multiple platforms is to save the platform as a scene and then copy paste the scene.  
-Save either platform as a scene by right clicking the static body and selecting Save Branch as Scene.
+Save either platform as a scene by right clicking the static body and selecting **Save Branch as Scene**.
 
 ### Interaction
 
@@ -158,30 +163,30 @@ You were wrong, let's make a button that makes some text appear on the screen.
 
 #### The text
 
-First, the text. As a child of Camera3D, add Label.
+First, the text. As a child of **Camera3D**, add **Label**.
 Give the label some text and move it to the center of the feint camera box.
 
 It should look something like this:
 ![Label](../../../../../assets/godot/3D/Label.png)
-Feel free to change the label to a RichTextLabel and mess around with making it look pretty.
+Feel free to change the label to a **RichTextLabel** and mess around with making it look pretty.
 
-After making your text, select your label and in the inspector go to CanvasItem > Visibility and turn Visible off, we will be making it visible with code.
+After making your text, select your label and in the inspector go to **CanvasItem > Visibility** and turn **Visible** off, we will be making it visible with code.
 
 #### The button
 
-Add a new StaticBody3D, with a mesh and collider.
+Add a new **StaticBody3D**, with a mesh and collider.
 The only difference this time is to make it a floating cube instead of a plane.
 
-Select your new static body and go to the Node tab, which is found next to the inspector tab.
-Go to groups and type in "Button" and press Add.
+Select your new static body and go to the **Node** tab, which is found next to the inspector tab.
+Go to groups and type in "Button" and press **Add**.
 
-Add a RayCast3D as a child of your Camera3D and move it to aim in the same direction as the camera and move it to the same position as where the camera originates.  
+Add a **RayCast3D** as a child of your **Camera3D** and move it to aim in the same direction as the camera and move it to the same position as where the camera originates.  
 Your button and ray cast should look something like this:
 ![Button and ray cast](../../../../../assets/godot/3D/RayCastButton.png)
 Then, decrease the ray cast's target position's y to -3 or lower.
 
-Now, go to the script on your player and add an onready variable for the ray cast and label similar to how the `main_camera` is.
-When you have `@onready var name = ` you can just drag the node from the scene tree into the script, and it will automatically fill in the variable path and add $.
+Now, go to the script on your player and add an `@onready` variable for the ray cast and label similar to how the `main_camera` is.
+When you have `@onready var your_var_name = ` you can just drag the node from the scene tree into the script, and it will automatically fill in the variable path and add $.
 
 Next add the action for your interact button, like you did for the movement keys. E or F are good buttons for basic world interaction, and name it something like 'interact'.
 
@@ -201,7 +206,7 @@ Boom! Interaction. That might not have seemed very difficult, but knowing to use
 Now if you play the game, look at the cube, and press your interaction button it should show text on screen.
 This is a game. What you have made is a game. It might not look like it, but if you had beautiful art it would.
 
-If you made some 3D models of platforms, a button, a character, and added a skybox it would look like a real game. That's truly the only difference. Well that and maybe some more platforms to jump around on.
+If you made some 3D models of platforms, a button, a character, and added a skybox it would look like a real game. That's truly the only difference. Well that and maybe a goal.
 
 ## What next?
 
@@ -209,7 +214,8 @@ Make a game!
 
 ### How?
 
-Lots of googling and frustration as you figure things out. The [Godot docs](https://docs.godotengine.org/en/stable/) are your best friend. If you haven't been following along with the coding portions, then try going back to the basics guide and do the challenges near the end.
+Lots of googling and frustration as you figure things out. The [Godot docs](https://docs.godotengine.org/en/stable/) are your best friend.
+If you haven't been following along with the coding portions, then try going back to the basics guide and do the challenges near the end.
 
 ### What?
 
@@ -220,6 +226,7 @@ If your goal is to make this a job, show a game company your game portfolio afte
 [Here is a list of game developers in New Zealand](https://www.gamedevmap.com/index.php?country=New%20Zealand).
 You should try making games for your portfolio in the software they use before applying.
 [Godot is unlikely to be used](https://godotengine.org/article/whats-missing-in-godot-for-aaa/), but your time has not been wasted since it still uses the same fundamentals and many indie studios are moving to Godot.
+Godot is also expecially good for learning high level concepts.
 
 An even better option would be to join a game jam, which is a competition where you make a game in a short amount of time.
 They are wildly popular and are absolutely the best way to learn and dip your toes in new areas you haven't before.  

--- a/src/content/docs/guides/game-design/godot/3d.mdx
+++ b/src/content/docs/guides/game-design/godot/3d.mdx
@@ -16,23 +16,25 @@ This guide is up-to-date with Godot 4.1.3 stable official release but will most 
 Making the project is just as easy as 2D.
 ![Godot new project window](../../../../../assets/godot/3D/NewProject.png)
 
-Make sure your project is set to Forward+.
+Make sure your project is set to **Forward+**.
 
 :::note[Different renderers]
 In 2D, what renderer you choose has minimal effect on your final outcome due to how simple 2D images are to draw to a screen.
 With 3D, there is a large disparity between the renderers.
-Read the notes next to each renderer before picking something other than Forward+.
+Read the notes next to each renderer before picking something other than **Forward+**.
 :::
 
 ![Create root node, 3D Scene highlighted](../../../../../assets/godot/3D/CreateRootNode.png)
 
 Set the root node to 3D and your project is set up!  
-Although, go ahead and save the scene with Scene > Save Scene so you have the scene file saved.
+Although, go ahead and save the scene with **Scene > Save Scene** so you have the scene file saved.
+
+### Navigating the 3D viewport
 
 Before adding things to your scene, you should know how to move around in the viewport.  
-Press down the middle mouse button to rotate the camera. Zoom in and out by scrolling. Shift+Middle Mouse to pan. Right click to turn and while right click is down you can press WASD-QE to fly. Press F to recentre the camera on the selected object.  
+Press down the middle mouse button to rotate the camera. Zoom in and out by scrolling. Shift+Middle Mouse to pan. Right click to turn and while right click is down you can press WASD-QE to fly. Press F to recentre the camera on the selected object. 
 :::note[Devices without a middle mouse button]
-If you do not have a middle mouse button to press, go to Editor > Editor Settings... > Editors > 3D and turn Emulate 3 Button Mouse on. Now you will use Alt to rotate and Shift to pan.
+If you do not have a middle mouse button to press, go to **Editor > Editor Settings... > Editors > 3D** and turn **Emulate 3 Button Mouse** on. Now you will use Alt to rotate and Shift to pan.
 :::
 
 
@@ -63,8 +65,10 @@ Now when you play the game and press **down** on the arrow keys you should move 
 Most modern 3D games have a first person camera, which can be pretty complicated. Open the script on your player.
 In this script, add these lines below `var gravity` and above `func _physics_process(delta):`:  
 
-:::warning[Copy pasting]
+:::caution[Copy pasting]
 More likely than not you'll copy paste this with spaces instead of tabs. Godot is strict with using just tabs. After copy pasting this, replace all the space indents with tabs.
+
+Make sure everything is indented the same amount as it shows on the site.
 :::
 
 ```gdscript
@@ -111,11 +115,16 @@ func camera_look(movement: Vector2) -> void:
 :::note[Understanding the code]
 If you want to understand this code, you should read the Godot docs on [Using Transforms](https://docs.godotengine.org/en/stable/tutorials/3d/using_transforms.html).
 Then try making a third-person camera! (A camera that hovers behind the shoulder of the player)
+
 You will need to add a capsule mesh to the CharacterBody3D, so the player is visible.
-Keep in mind, the y rotation shouldn't be centered on the camera but on the player's head.  
+
+The tricky part here is the y rotation shouldn't be centered on the camera but on the player's head.  
 Here's an example of what it should look like:
 ![Third person camera](../../../../../assets/godot/3D/ThirdPersonCamera.gif)
 :::
+
+#### Changing the controls
+
 The mouse sensitivity variable controls how fast the camera moves, change it to suit your preference.
 
 This is all you need for a basic character controller, but, as is good practice, you should change the input keys.
@@ -154,14 +163,14 @@ To fix that you'll need to select the **CollisionShape3D** and make a new **BoxS
 A better way of making multiple platforms is to save the platform as a scene and then copy paste the scene.  
 Save either platform as a scene by right clicking the static body and selecting **Save Branch as Scene**.
 
-### Interaction
+## Interaction
 
 You think pressing a button is easy?  
 You think it's just simple to add a thing that you walk up to and press a button to interact with when looking at it.
 
 You were wrong, let's make a button that makes some text appear on the screen.
 
-#### The text
+### The text
 
 First, the text. As a child of **Camera3D**, add **Label**.
 Give the label some text and move it to the center of the feint camera box.
@@ -170,9 +179,9 @@ It should look something like this:
 ![Label](../../../../../assets/godot/3D/Label.png)
 Feel free to change the label to a **RichTextLabel** and mess around with making it look pretty.
 
-After making your text, select your label and in the inspector go to **CanvasItem > Visibility** and turn **Visible** off, we will be making it visible with code.
+After making your text, select your label and, in the inspector, go to **CanvasItem > Visibility** and turn **Visible** off, we will be making it visible with code.
 
-#### The button
+### The button and raycast
 
 Add a new **StaticBody3D**, with a mesh and collider.
 The only difference this time is to make it a floating cube instead of a plane.
@@ -184,6 +193,8 @@ Add a **RayCast3D** as a child of your **Camera3D** and move it to aim in the sa
 Your button and ray cast should look something like this:
 ![Button and ray cast](../../../../../assets/godot/3D/RayCastButton.png)
 Then, decrease the ray cast's target position's y to -3 or lower.
+
+### Scripting
 
 Now, go to the script on your player and add an `@onready` variable for the ray cast and label similar to how the `main_camera` is.
 When you have `@onready var your_var_name = ` you can just drag the node from the scene tree into the script, and it will automatically fill in the variable path and add $.


### PR DESCRIPTION
honestly the 3D docs get across all that needs to be gotten across 
I'll add a lot more content of how to do things when I make example game docs instead of just 2D and 3D 

In this I made the style more consistent between the 2D and 3D docs, and just generally made the docs more clear all over too unlike the 2D docs which were sorely lacking all over